### PR TITLE
ember-getOwner-polyfill fix

### DIFF
--- a/blueprints/ember-gestures/index.js
+++ b/blueprints/ember-gestures/index.js
@@ -16,7 +16,7 @@ module.exports = {
     ];
 
     var checker = new VersionChecker(addon);
-    if (checker.for('ember', 'bower').satisfies('>= 2.3')) {
+    if (checker.forEmber().satisfies('>= 2.3') === false) {
       addonPackages.push({name: 'ember-getowner-polyfill', target: '^1.0.0'});
     }
 


### PR DESCRIPTION
ember-getOwner-polyfill should be added to packages if ember version is less than 2.3 and not satisfied

