### PR TITLE
Use Object.prototype.hasOwnProperty for checking if module exists

### DIFF
--- a/addon/event_dispatcher.js
+++ b/addon/event_dispatcher.js
@@ -197,7 +197,7 @@ function getModuleList() {
   const list = [];
 
   for(var moduleName in requirejs.entries) {
-    if (requirejs.entries.hasOwnProperty(moduleName)) {
+    if (Object.prototype.hasOwnProperty.call(requirejs.entries, moduleName)) {
       const parts = moduleName.match(/ember-gestures\/recognizers\/(.*)/);
 
       if (parts && parts[1].indexOf('jshint') === -1) {


### PR DESCRIPTION
This line causes the following error:

```TypeError: requirejs.entries.hasOwnProperty is not a function```

due to this commit to loader.js: https://github.com/ember-cli/loader.js/commit/8a342966e37844040b6d87a1e72d04d477c1eef5

Using the prototype's hasOwnProperty avoids any surprises.