### PR TITLE
fix getOwner deprecations

### DIFF
--- a/addon/event_dispatcher.js
+++ b/addon/event_dispatcher.js
@@ -3,7 +3,6 @@ import defaultHammerEvents from './hammer-events';
 import dasherizedToCamel from 'ember-allpurpose/string/dasherized-to-camel';
 import jQuery from 'jquery';
 import mobileDetection from './utils/is-mobile';
-import getOwner from 'ember-getowner-polyfill';
 
 let ROOT_ELEMENT_CLASS = 'ember-application';
 let ROOT_ELEMENT_SELECTOR = '.' + ROOT_ELEMENT_CLASS;
@@ -20,6 +19,7 @@ const eventEndings = {
 const {
   assert,
   EventDispatcher,
+  getOwner,
   merge,
   isNone,
   set,

--- a/addon/mixins/recognizers.js
+++ b/addon/mixins/recognizers.js
@@ -1,8 +1,8 @@
 import Ember from 'ember';
-import getOwner from 'ember-getowner-polyfill';
 
 const {
   computed,
+  getOwner,
   inject,
   Mixin,
   on

--- a/addon/services/-gestures.js
+++ b/addon/services/-gestures.js
@@ -1,10 +1,10 @@
 import Ember from 'ember';
 import camelize from 'ember-allpurpose/string/dasherized-to-camel';
 import capitalize from 'ember-allpurpose/string/capitalize-word';
-import getOwner from 'ember-getowner-polyfill';
 
 const {
   computed,
+  getOwner,
   Service,
   RSVP
 } = Ember;

--- a/app/instance-initializers/ember-gestures.js
+++ b/app/instance-initializers/ember-gestures.js
@@ -1,4 +1,6 @@
-import getOwner from 'ember-getowner-polyfill';
+import Ember from 'ember';
+
+const { getOwner } = Ember;
 
 export default {
   name: 'ember-gestures',

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "liquid-fire": "0.23.0",
     "loader.js": "^4.0.1",
     "ember-cli-content-security-policy": "^0.4.0",
-    "ember-getowner-polyfill": "^1.0.0",
+    "ember-getowner-polyfill": "^1.2.2",
     "ember-velocity-mixin": "0.3.0"
   },
   "keywords": [


### PR DESCRIPTION
`ember-getowner-polyfill` is now a true polyfill and raises deprecations if is used with import