### PR TITLE
Remove dependency on bower

### DIFF
--- a/blueprints/ember-gestures/index.js
+++ b/blueprints/ember-gestures/index.js
@@ -8,9 +8,7 @@ module.exports = {
 
   afterInstall: function() {
     var addon = this;
-    var bowerPackages = [
-      { name: 'hammer.js', target: '2.0.6' }
-    ];
+
     var addonPackages = [
       { name: 'ember-hammertime', target: '^1.1.2' }
     ];
@@ -21,8 +19,6 @@ module.exports = {
       addonPackages.push({name: 'ember-getowner-polyfill', target: '^1.0.0'});
     }
 
-    return addon.addBowerPackagesToProject(bowerPackages).then(function() {
-      return addon.addAddonsToProject({ packages: addonPackages });
-    });
+    return addon.addAddonsToProject({ packages: addonPackages })
   }
 };

--- a/bower.json
+++ b/bower.json
@@ -8,9 +8,5 @@
     "ember-qunit-notifications": "0.1.0",
     "animation-frame": "~0.2.4",
     "marked": "~0.3.5"
-  },
-  "devDependencies": {
-    "hammer-time": "1.0.0",
-    "hammer.js": "2.0.6"
   }
 }

--- a/index.js
+++ b/index.js
@@ -2,6 +2,10 @@
 /* global process */
 'use strict';
 
+let path = require('path');
+let Funnel = require('broccoli-funnel');
+let MergeTrees = require('broccoli-merge-trees');
+
 module.exports = {
 
   name: 'ember-gestures',
@@ -16,11 +20,19 @@ module.exports = {
 
     if (!process.env.EMBER_CLI_FASTBOOT) {
       if (app.env === "production") {
-        app.import(app.bowerDirectory + '/hammer.js/hammer.min.js');
+        app.import('vendor/hammer.min.js');
       } else {
-        app.import(app.bowerDirectory + '/hammer.js/hammer.js');
+        app.import('vendor/hammer.js');
       }
     }
+  },
+
+  treeForVendor(vendorTree) {
+    let hammerTree = new Funnel(path.dirname(require.resolve('hammerjs/hammer.js')), {
+      files: ['hammer.js', 'hammer.min.js']
+    });
+
+    return new MergeTrees([vendorTree, hammerTree]);
   },
 
   isDevelopingAddon: function() {

--- a/package.json
+++ b/package.json
@@ -65,10 +65,13 @@
     "pointer events"
   ],
   "dependencies": {
+    "broccoli-funnel": "^1.1.0",
+    "broccoli-merge-trees": "^2.0.0",
     "ember-cli-version-checker": "^1.2.0",
     "ember-allpurpose": "^1.1.0",
     "ember-cli-babel": "^5.1.5",
     "ember-cli-htmlbars": "^1.0.1",
+    "hammerjs": "^2.0.8",
     "rsvp": "^3.1.0"
   },
   "ember-addon": {


### PR DESCRIPTION
Bower is now optional in ember, so it makes sense to pull in the deps using npm