### PR TITLE
Fix for upcoming FastBoot 1.0 breaking changes

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,15 +2,16 @@
 /* global process */
 'use strict';
 
-let path = require('path');
-let Funnel = require('broccoli-funnel');
-let MergeTrees = require('broccoli-merge-trees');
+const path = require('path');
+const Funnel = require('broccoli-funnel');
+const MergeTrees = require('broccoli-merge-trees');
+const map = require('broccoli-stew').map;
 
 module.exports = {
 
   name: 'ember-gestures',
 
-  included: function (app) {
+  included(app) {
     this._super.included.apply(this, arguments);
 
     // see: https://github.com/ember-cli/ember-cli/issues/3718
@@ -18,20 +19,19 @@ module.exports = {
       app = app.app;
     }
 
-    if (!process.env.EMBER_CLI_FASTBOOT) {
-      app.import('vendor/hammer.js');
-    }
+    app.import('vendor/hammer.js');
   },
 
   treeForVendor(vendorTree) {
     let hammerTree = new Funnel(path.dirname(require.resolve('hammerjs')), {
       files: ['hammer.js']
     });
+    hammerTree = map(hammerTree, (content) => `if (typeof FastBoot === 'undefined') { ${content} }`);
 
     return new MergeTrees([vendorTree, hammerTree]);
   },
 
-  isDevelopingAddon: function() {
+  isDevelopingAddon() {
     return false;
   }
 

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "ember-cli-version-checker": "^1.2.0",
     "ember-allpurpose": "^1.1.0",
     "ember-cli-babel": "^5.1.5",
-    "ember-cli-htmlbars": "^1.0.1",
+    "ember-cli-htmlbars": "^1.2.0",
     "ember-getowner-polyfill": "^1.2.2",
     "hammerjs": "^2.0.8",
     "rsvp": "^3.1.0"


### PR DESCRIPTION
`process.env.EMBER_CLI_FASTBOOT` will be gone in FastBoot 1.0. This should now work in pre and post 1.0 versions of `ember-cli-fastboot`. See https://github.com/ember-fastboot/ember-cli-fastboot/issues/360 for context.