### PR TITLE
Remove ember-allpurpose

### DIFF
--- a/addon/components/gesture-element.js
+++ b/addon/components/gesture-element.js
@@ -1,7 +1,7 @@
 import Ember from 'ember';
 import layout from '../templates/components/gesture-element';
 import RecognizerMixin from '../mixins/recognizers';
-import toCamel from 'ember-allpurpose/string/dasherized-to-camel';
+import toCamel from '../utils/string/dasherized-to-camel';
 
 const {
   Component,

--- a/addon/event_dispatcher.js
+++ b/addon/event_dispatcher.js
@@ -1,6 +1,6 @@
 import Ember from 'ember';
 import defaultHammerEvents from './hammer-events';
-import dasherizedToCamel from 'ember-allpurpose/string/dasherized-to-camel';
+import dasherizedToCamel from './utils/string/dasherized-to-camel';
 import jQuery from 'jquery';
 import mobileDetection from './utils/is-mobile';
 

--- a/addon/services/-gestures.js
+++ b/addon/services/-gestures.js
@@ -1,6 +1,6 @@
 import Ember from 'ember';
-import camelize from 'ember-allpurpose/string/dasherized-to-camel';
-import capitalize from 'ember-allpurpose/string/capitalize-word';
+import camelize from '../utils/string/dasherized-to-camel';
+import capitalize from '../utils/string/capitalize-word';
 
 const {
   computed,

--- a/addon/utils/string/cap-first-letter.js
+++ b/addon/utils/string/cap-first-letter.js
@@ -1,0 +1,3 @@
+export default function (s) {
+  return s.charAt(0).toUpperCase() + s.slice(1);
+}

--- a/addon/utils/string/capitalize-word.js
+++ b/addon/utils/string/capitalize-word.js
@@ -1,0 +1,3 @@
+export default function (s) {
+  return s.charAt(0).toUpperCase() + s.slice(1);
+}

--- a/addon/utils/string/capitalize-words.js
+++ b/addon/utils/string/capitalize-words.js
@@ -1,0 +1,9 @@
+import capFirstLetter from "./cap-first-letter";
+
+export default function (sentence) {
+  return sentence.split(' ')
+    .map(function (word) {
+      return capFirstLetter(word);
+    })
+    .join(' ');
+}

--- a/addon/utils/string/dasherized-to-camel.js
+++ b/addon/utils/string/dasherized-to-camel.js
@@ -1,0 +1,11 @@
+import uncapitalize from './uncapitalize-word';
+import dashToWords from './dasherized-to-words';
+import capitalizeWords from './capitalize-words';
+import stripWhiteSpace from './strip-whitespace';
+
+export default function(s) {
+  return uncapitalize(
+    stripWhiteSpace(
+      capitalizeWords(
+        dashToWords(s))));
+}

--- a/addon/utils/string/dasherized-to-words.js
+++ b/addon/utils/string/dasherized-to-words.js
@@ -1,0 +1,3 @@
+export default function dasherizedToWords(s) {
+  return s.replace(/-/g, ' ');
+};

--- a/addon/utils/string/strip-whitespace.js
+++ b/addon/utils/string/strip-whitespace.js
@@ -1,0 +1,3 @@
+export default function stripWhiteSpace(s) {
+  return s.replace(/\s/g, '');
+}

--- a/addon/utils/string/uncapitalize-word.js
+++ b/addon/utils/string/uncapitalize-word.js
@@ -1,0 +1,3 @@
+export default function (s) {
+  return s.charAt(0).toLowerCase() + s.slice(1);
+}

--- a/package.json
+++ b/package.json
@@ -40,10 +40,9 @@
   "dependencies": {
     "broccoli-funnel": "^1.1.0",
     "broccoli-merge-trees": "^2.0.0",
-    "ember-cli-version-checker": "^1.2.0",
-    "ember-allpurpose": "^1.1.0",
     "ember-cli-babel": "^6.0.0",
     "ember-cli-htmlbars": "^2.0.1",
+    "ember-cli-version-checker": "^1.2.0",
     "ember-getowner-polyfill": "^1.2.3",
     "hammerjs": "^2.0.8",
     "rsvp": "^3.1.0"
@@ -68,8 +67,8 @@
     "ember-hammertime": "^1.2.3",
     "ember-load-initializers": "^1.0.0",
     "ember-resolver": "^4.0.0",
-    "ember-source": "~2.14.0-beta.1",
     "ember-run-raf": "runspired/ember-run-raf",
+    "ember-source": "~2.14.0-beta.1",
     "ember-velocity-mixin": "0.3.0",
     "liquid-fire": "0.27.3",
     "loader.js": "^4.2.3"

--- a/tests/unit/utils/string-test.js
+++ b/tests/unit/utils/string-test.js
@@ -1,0 +1,39 @@
+import { test } from 'ember-qunit';
+import toCamel from 'ember-gestures/utils/string/dasherized-to-camel';
+import capitalize from 'ember-gestures/utils/string/capitalize-word';
+import uncapitalize from 'ember-gestures/utils/string/uncapitalize-word';
+import stripWhiteSpace from 'ember-gestures/utils/string/strip-whitespace';
+import capitalizeWords from 'ember-gestures/utils/string/capitalize-words';
+import dashToWords from 'ember-gestures/utils/string/dasherized-to-words';
+
+test('toCamel: properly camelizes basic string', function(assert) {
+  assert.equal(toCamel('FooBar'), 'fooBar');
+});
+
+test('toCamel: properly capitalizes sequences of words', function(assert) {
+  assert.equal(toCamel('Foo bar Baz Quux'), 'fooBarBazQuux');
+});
+
+test('capitalize: capitalizes the first character of a string', function(assert) {
+  assert.equal(capitalize('foobar'), 'Foobar');
+});
+
+test('uncapitalize: uncapitalizes the first character of a string', function(assert) {
+  assert.equal(uncapitalize('Foobar'), 'foobar');
+});
+
+test('uncapitalize: is a noop when first character needs no work done', function(assert) {
+  assert.equal(uncapitalize('foobar'), 'foobar');
+});
+
+test('stripWhitespace: removes whitespace from string', function(assert) {
+  assert.equal(stripWhiteSpace('foo bar'), 'foobar');
+});
+
+test('capitalizeWords: capitalizes each string in given sequence', function(assert) {
+  assert.equal(capitalizeWords('foo bar baz quux'), 'Foo Bar Baz Quux');
+});
+
+test('dashToWords: takes dasherized string and splits to sequence', function(assert) {
+  assert.equal(dashToWords('foo-bar-baz'), 'foo bar baz');
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -2140,13 +2140,7 @@ electron-to-chromium@^1.3.14:
   version "1.3.14"
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.14.tgz#64af0f9efd3c3c6acd57d71f83b49ca7ee9c4b43"
 
-ember-allpurpose@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/ember-allpurpose/-/ember-allpurpose-1.1.0.tgz#9a299475f3ab2635591592bc1540d4555cad29e8"
-  dependencies:
-    ember-cli-babel "^5.0.0"
-
-ember-cli-babel@^5.0.0, ember-cli-babel@^5.1.5, ember-cli-babel@^5.1.6, ember-cli-babel@^5.1.7:
+ember-cli-babel@^5.1.5, ember-cli-babel@^5.1.6, ember-cli-babel@^5.1.7:
   version "5.2.4"
   resolved "https://registry.yarnpkg.com/ember-cli-babel/-/ember-cli-babel-5.2.4.tgz#5ce4f46b08ed6f6d21e878619fb689719d6e8e13"
   dependencies:
@@ -2513,7 +2507,7 @@ ember-factory-for-polyfill@^1.1.0:
     ember-cli-babel "^5.1.7"
     ember-cli-version-checker "^1.2.0"
 
-ember-getowner-polyfill@^1.1.1, ember-getowner-polyfill@^1.2.2:
+ember-getowner-polyfill@^1.1.1, ember-getowner-polyfill@^1.2.3:
   version "1.2.3"
   resolved "https://registry.yarnpkg.com/ember-getowner-polyfill/-/ember-getowner-polyfill-1.2.3.tgz#ea70f4a48b1c05b91056371d1878bbafe018222e"
   dependencies:


### PR DESCRIPTION
Removes ember-allpurpose dependency.  The dependency is only used in 3(ish) places, and contributes about 9k worth of utilities.   Found this out when reviewing an app with broccoli-concat-analyzer: 

![screen shot 2017-09-05 at 3 37 29 pm](https://user-images.githubusercontent.com/75710/30080017-30b1c55a-9250-11e7-8d45-e32a8c1355c2.png)

Pulled the exact functions used within ember-allpurpose.  We lose the ability for these to be updated, but they seem stable enough to pull in this way and will save 9k compressed payload to anyone using this lib.

:beers: