### PR TITLE
Remove depreciated canDispatchToEventManager

### DIFF
--- a/addon/event_dispatcher.js
+++ b/addon/event_dispatcher.js
@@ -39,9 +39,7 @@ export default EventDispatcher.extend({
    */
   useFastPaths: false,
   useCapture: false,
-
-  canDispatchToEventManager: false,
-
+  
   _gestures: null,
   _initializeGestures() {
     const list = getModuleList();


### PR DESCRIPTION
Remove depreciated canDispatchToEventManager

Depreciated Message:
```
DEPRECATION: `canDispatchToEventManager` has been deprecated in (EventDispatcher). [deprecation id: ember-views.event-dispatcher.canDispatchToEventManager]
        at logDeprecationStackTrace (http://school1.bloowatch.com/assets/vendor.js:29457:21)
        at HANDLERS.(anonymous function) (http://school1.bloowatch.com/assets/vendor.js:29669:9)
        at raiseOnDeprecation (http://school1.bloowatch.com/assets/vendor.js:29487:14)
        at HANDLERS.(anonymous function) (http://school1.bloowatch.com/assets/vendor.js:29669:9)
        at invoke (http://school1.bloowatch.com/assets/vendor.js:29681:9)
        at deprecate (http://school1.bloowatch.com/assets/vendor.js:29541:24)
        at Class.init (http://school1.bloowatch.com/assets/vendor.js:62815:87)
        at Class.superWrapper [as init] (http://school1.bloowatch.com/assets/vendor.js:61416:22)
        at new Class (http://school1.bloowatch.com/assets/vendor.js:56726:19)
```