### PR TITLE
chore(deps): replace deprecated internal copy with ember-copy. id: em…

### DIFF
--- a/addon/components/slide-toggle.js
+++ b/addon/components/slide-toggle.js
@@ -1,6 +1,6 @@
 import { alias } from '@ember/object/computed';
 import { run } from '@ember/runloop';
-import { copy } from '@ember/object/internals';
+import { copy } from 'ember-copy';
 import Component from '@ember/component';
 import VelocityMixin from 'ember-velocity-mixin';
 import RecognizerMixin from '../mixins/recognizers';

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "ember-cli-babel": "^6.8.2",
     "ember-cli-htmlbars": "^2.0.1",
     "ember-cli-version-checker": "^2.1.0",
+    "ember-copy": "^1.0.0",
     "ember-getowner-polyfill": "^2.2.0",
     "hammerjs": "^2.0.8",
     "rsvp": "^3.1.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2528,6 +2528,12 @@ ember-code-snippet@^1.2.1:
     glob "^4.0.4"
     highlight.js "^9.5.0"
 
+ember-copy@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/ember-copy/-/ember-copy-1.0.0.tgz#426554ba6cf65920f31d24d0a3ca2cb1be16e4aa"
+  dependencies:
+    ember-cli-babel "^6.6.0"
+
 ember-disable-prototype-extensions@^1.1.2:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/ember-disable-prototype-extensions/-/ember-disable-prototype-extensions-1.1.3.tgz#1969135217654b5e278f9fe2d9d4e49b5720329e"


### PR DESCRIPTION
This updates deprecated internal ember/object/internals copy to use addon-copy. 
